### PR TITLE
Update to custom question answering

### DIFF
--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/MainWindow.xaml
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/MainWindow.xaml
@@ -14,7 +14,7 @@
 
             <Button Content="{Binding SourceDocumentURL}" 
                     Command="{Binding ViewDocumentCommand}" 
-                   Visibility="{Binding Path=SourceDoumentURL, Converter={StaticResource NullStringToVisibilityConverter}}"/>
+                   Visibility="{Binding Path=SourceDocumentURL, Converter={StaticResource NullStringToVisibilityConverter}}"/>
 
         </DataTemplate>
         <DataTemplate x:Key="AnswerTextCellTemplate">

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/Providers/IQnAGateway.cs
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/Providers/IQnAGateway.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models;
+﻿using Azure.AI.Language.QuestionAnswering;
 using System.Threading.Tasks;
 
 namespace QnAMakerRuntimeAPI.Providers
 {
     public interface IQnAGateway
     {
-        Task<QnASearchResultList> AnswerQuestion(string question, string userId = "user1", int resultCount = 1);
+        Task<AnswersResult> AnswerQuestion(string question, string userId = "user1", int resultCount = 1);
     }
 }

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/Providers/QnAGateway.cs
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/Providers/QnAGateway.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
-using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker;
-using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
+using Azure.AI.Language.QuestionAnswering;
+using Azure.Core;
+using Azure;
 
 namespace QnAMakerRuntimeAPI.Providers
 {
@@ -18,32 +18,34 @@ namespace QnAMakerRuntimeAPI.Providers
             _configuration = config;
         }
 
-        public async Task<QnASearchResultList> AnswerQuestion(string question, string userId, int resultCount = 1)
+        public async Task<AnswersResult> AnswerQuestion(string question, string userId, int resultCount = 1)
         {
-            //From QnA Knowledgebase - embedded GUID in POST portion
-            var runtimeKB = _configuration["QNA_KB_ID"];
-            //From QnA Knowledgebase - HOST
-            var runtimeEndpoint = _configuration["QNA_RuntimeEndpoint"];
-            //From QnA Knowledgebase - Authorization Endpoint Key
-            var runtimeKey = _configuration["QNA_RuntimeKey"];
+            //From the Deploy Knowledge Base page in Language Studio - Prediction URL, but drop everything after azure.com becuase 
+            //the SDK will supply those settings. Your url should look like this when using the SDK: https://<My Language Service>.cognitiveservices.azure.com"
+            var runtimeEndpoint = new Uri(_configuration["QuestionAnswering.Endpoint"]);
+            //From Azure Portal Language resource - Keys and Endpoint, pick one of the keys.
+            var runtimeKey = _configuration["QuestionAnswering.APIKey"];
+            //From the Deploy Knowledge Base page in Language Studio (Can extract projectName and DeploymentName from the example Prediction URL)
+            string projectName = _configuration["QuestionAnswering.ProjectName"];
+            string deploymentName = _configuration["QuestionAnswering.DeploymentName"];
 
-            var runtimeCreds = new EndpointKeyServiceClientCredentials(runtimeKey);
+            var runtimeCreds = new AzureKeyCredential(runtimeKey);
 
             //Runtime client for asking questions
-            using (QnAMakerRuntimeClient rtClient = new QnAMakerRuntimeClient(runtimeCreds) { 
-                RuntimeEndpoint = runtimeEndpoint 
-            })
+            QuestionAnsweringClient rtClient = new QuestionAnsweringClient(runtimeEndpoint,runtimeCreds);
+
+            AnswersOptions options = new AnswersOptions()
             {
-                QueryDTO query = new QueryDTO()
-                {
-                    Question = question, //The text of the question
-                    ScoreThreshold = 0.55, //The minimum relevance score to accept
-                    Top = resultCount //How many answers to return, maximum
-                };
+                ConfidenceThreshold = 0.39,//The minimum relevance score to accept
+                Size = resultCount//How many answers to return, maximum
+            };
+              
+          
+            QuestionAnsweringProject project = new QuestionAnsweringProject(projectName, deploymentName);
 
-               return await rtClient.Runtime.GenerateAnswerAsync(runtimeKB, query).ConfigureAwait(false);
-
-            }
+         
+            return await rtClient.GetAnswersAsync(question, project, options);
+         
 
         }
 

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI.csproj
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <UserSecretsId>8d13aee1-9fe8-49bd-bb53-346820112b60</UserSecretsId>
   </PropertyGroup>

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI.csproj
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI.csproj
@@ -12,15 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Doc\" />
     <Folder Include="UICore\Converters\" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.1" />
+    <PackageReference Include="Azure.AI.Language.QuestionAnswering" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/UICore/Converters/NullToVisiblityConverter.cs
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/UICore/Converters/NullToVisiblityConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Windows;
 using System.Windows.Data;

--- a/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/appSettings.json
+++ b/QnAMakerRuntimeAPI/QnAMakerRuntimeAPI/appSettings.json
@@ -1,7 +1,7 @@
 ﻿{
-  
-  "QNA_RuntimeEndpoint": "",
-  "QNA_RuntimeKey": "",
-  "QNA_KB_ID": "",
+  "QuestionAnswering.Endpoint": "",
+  "QuestionAnswering.APIKey": "",
+  "QuestionAnswering.ProjectName": "",
+  "QuestionAnswering.DeploymentName": "production",
   "HelpDocumentsPath": "C:\\HelpFiles"
 }


### PR DESCRIPTION
Updated the QnAMaker client Project to .NET 6, and then converted it to connect to the new Language Service Custom Question Answering , which is the new home for what was QnA Maker. This was in response to QnAMaker being deprecated.
The tasks include:
1. Creating a new Language service in Azure and enabling the Custom Question Answering feature. This also creates a new Azure Search resource.
2. Using QnA maker portal (qnamaker.ai) to migrate the existing KB to the new service. It is a wizard-like experience, but you must have completed step 1 to have something to migrate to.
3. Deploying the knowledge base using Language Studio, accessed via the Azure Portal from the Language resource.
4. Using the Confidence Threshold Mapper in the QnA Portal to get an equivalent confidence threshold number to use in code. 
5. Updating the code used to connect to QnA maker to now connect to Custom Question Answering (the code in this repo), which included:
a. New configuration settings to match the new service requirements
b. Importing azure.ai.language.questionanswering and removing Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker
c. Switching code to use the new library. They were similar, so this was not hard. 